### PR TITLE
fix#01: recommend logic error fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2576,9 +2576,9 @@
       }
     },
     "node_modules/@rollup/plugin-terser/node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"

--- a/src/api/spotify/artistApi.ts
+++ b/src/api/spotify/artistApi.ts
@@ -8,12 +8,12 @@ export const getArtistInfo = async (artist_id: any) => {
 		const { artists } = data;
 		return artists;
 	} catch (error) {
-		console.error(error);
+		console.error("getArtisiInfoError:", error);
 	}
 };
 
 /** SPOTIFY DOCS: Get Artist's Top Tracks 참조
- *  아티스트 id로 top track 가져오는 API 단, id는 단수 
+ *  아티스트 id로 top track 가져오는 API 단, id는 단수
  * */
 export const getArtistTopTracks = async (artist_id: any) => {
 	try {
@@ -28,27 +28,28 @@ export const getArtistTopTracks = async (artist_id: any) => {
 	}
 };
 
-
 export const getArtistAlbums = async (artist_id: string) => {
-  try {
-    const response = await baseInstance(`artists/${artist_id}/albums?market=KR`)
-    const data = response.data
-    const albumList = data.items
-    return { albumList }
-  } catch (error) {
-    console.error(error)
-    return error
-  }
-}
+	try {
+		const response = await baseInstance(
+			`artists/${artist_id}/albums?market=KR`,
+		);
+		const data = response.data;
+		const albumList = data.items;
+		return { albumList };
+	} catch (error) {
+		console.error(error);
+		return error;
+	}
+};
 
 export const getRelatedArtists = async (artist_id: string) => {
-  try {
-    const response = await baseInstance(`artists/${artist_id}/related-artists`)
-    const data = response.data
-    const artists = data.artists
-    return { artists }
-  } catch (error) {
-    console.error(error)
-    return error
-  }
-}
+	try {
+		const response = await baseInstance(`artists/${artist_id}/related-artists`);
+		const data = response.data;
+		const artists = data.artists;
+		return { artists };
+	} catch (error) {
+		console.error(error);
+		return error;
+	}
+};

--- a/src/components/recommend/ArtistSelector.tsx
+++ b/src/components/recommend/ArtistSelector.tsx
@@ -43,13 +43,16 @@ const ArtistSelector = () => {
 		enabled: !!genreStore,
 	});
 
-	/** b - 위에서 가져온 가수 id로 실제 데이터 가져오기 */
+	/** b - 위에서 가져온 가수 id로 실제 데이터 가져오기
+	 * 단, supabase에서 잠수함 패치릃 한것인지 기존에는 맥시멈 ids가 100이나 50개 이상이면
+	 * 에러가 발생하여 slice로 50개까지 잘라주었음
+	 */
 	const {
 		data: artistInfoBySpotify,
 		isLoading: isArtistIdsfromSupabaseLoading,
 	} = useQuery({
-		queryKey: ["detailData", selectedArtistIds],
-		queryFn: () => getArtistInfo(selectedArtistIds),
+		queryKey: ["detailData", selectedArtistIds?.slice(0, 50)],
+		queryFn: () => getArtistInfo(selectedArtistIds?.slice(0, 50)),
 		enabled: !!selectedArtistIds,
 	});
 


### PR DESCRIPTION
- 장르 선택후 가수 배열 호출 api 사용시 기존에는 파라미터 개수에 제한을 두지 않았으나 
   잠수함 패치가 일어난것인지 기존처럼 사용시 api콜이 많아졌다는 에러가 발생하여 slice메서드를 이용하여 파라미터로 최대 50개까지만 
   보내도록 수정해두었음


## 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->

## 상세 작업 내용
- todo
- todo

## ETC
<!-- 기타사항 -->

## 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->
- Close #{이슈번호}
